### PR TITLE
Create multi-stage Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,25 @@
+# This is now a multi-stage build file which fetches the required jar files directly
+
+# Stage 1 downloads the otp jar file
+FROM ubuntu:bionic as build
+
+WORKDIR /opt/build
+RUN apt-get update && \
+  apt-get install --yes curl && \
+  apt-get clean
+RUN curl -Lo otp.jar https://repo1.maven.org/maven2/org/opentripplanner/otp/1.4.0/otp-1.4.0-shaded.jar
+
+# Stage 2 creates the runtime
 FROM openjdk:10
 
 WORKDIR /opt/otp4gb
-RUN mkdir -p /opt/otp4gbl
-COPY otp-1.4.0-shaded.jar .
+COPY --from=build /opt/build/otp.jar .
 COPY graphs ./graphs
 
 EXPOSE 8080
 
 CMD [ "java", "-Xmx4G", \
-  "-jar", "otp-1.4.0-shaded.jar", \
+  "-jar", "otp.jar", \
   "--router", "centredonsouthyorkshire", \
   "--graphs", "graphs", \
   "--server" ]


### PR DESCRIPTION
I've moved the download of the otp jar file into a multi-stage docker build. This is step 1 of creating a streamlined pipeline for data processing resulting in

1. a very small OTP4GB git repository
2. the ability to create versions for arbitrary areas based on defining the extents of travel in a geojson file 3. the possibility of creating a CI pipeline to automagically create versions of this